### PR TITLE
Use an explicit python base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.8-slim
 WORKDIR /app
 ADD requirements.txt /app
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
The docker build fails for the newest `python:slim` base image. An explicit version should be used to avoid unintentional upgrades.